### PR TITLE
Fix Issue #29 Error in compilation repeated &AUX in lambda list

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -18,6 +18,7 @@
         #:cl-who
         #:pgcharts.dburi
         #:pgcharts.sql)
+  (:shadowing-import-from #:postmodern #:read-queries)
   (:import-from #:alexandria
                 #:read-file-into-string
                 #:read-file-into-byte-vector)

--- a/src/utils/dburi.lisp
+++ b/src/utils/dburi.lisp
@@ -19,10 +19,10 @@
   (:text t))
 
 (defrule dsn-port (and ":" (* (digit-char-p character)))
-  (:destructure (colon digits &aux (port (coerce digits 'string)))
+  (:destructure (colon digits)
 		(declare (ignore colon))
 		(list :port (if (null digits) digits
-				(parse-integer port)))))
+				(parse-integer (coerce digits 'string))))))
 
 (defrule doubled-at-sign (and "@@") (:constant "@"))
 (defrule doubled-colon   (and "::") (:constant ":"))


### PR DESCRIPTION
; caught ERROR:
;   during macroexpansion of
;   (DESTRUCTURING-BIND (COLON DIGITS &AUX ...) #:PRODUCTION2 ...). Use
;   *BREAK-ON-SIGNALS* to intercept.
;   
;    repeated &AUX in lambda list: (COLON DIGITS &AUX
;                                   (PORT (COERCE DIGITS 'STRING)) &AUX)
.
debugger invoked on a UIOP/LISP-BUILD:COMPILE-FILE-ERROR in thread
#<THREAD "main thread" RUNNING {10005684C3}>:
  COMPILE-FILE-ERROR while
  compiling #<CL-SOURCE-FILE "pgcharts" "src" "utils" "dburi">
